### PR TITLE
Adjust regex so that quotes will terminate valid tags.

### DIFF
--- a/lib/hashmonitor.coffee
+++ b/lib/hashmonitor.coffee
@@ -2,7 +2,7 @@
 
 Distribution = require('./stats').Distribution
 
-HASHTAG_REGEX = /\#([a-zA-Z][\w\d_]+)(?:(?:\s+|$)|\=(\-?\d+(?:\.\d+)?))/g
+HASHTAG_REGEX = /\#([a-zA-Z][\w\d_]+)(?:(?:[\s'"]+|$)|\=(\-?\d+(?:\.\d+)?))/g
 
 class HashMonitor
 

--- a/test/test-hashmonitor.coffee
+++ b/test/test-hashmonitor.coffee
@@ -104,6 +104,23 @@ exports["Can detect hashtags at the end of the line"] = (assert, done) ->
 
     done()
 
+exports["Can detect hashtags surrounded by quotes"] = (assert, done) ->
+
+  # Parse a bunch of lines.
+  monitor = new HashMonitor()
+  monitor.parse("'zippy #foo'")
+  monitor.parse('"fuzzy #foo"')
+
+  # Since the monitor runs asynchronously, we wait for the next event tick
+  # to see the results.
+  process.nextTick ->
+
+    stats = monitor.calculate()
+
+    assert.equals(stats.foo?, true, "expected to have metrics for #foo")
+    assert.equals(stats.foo.count, 2)
+
+    done()
 # Map CommonJS async test functions to the signature required by nodeunit.
 maptest = (description) ->
   cjstest = exports[description]


### PR DESCRIPTION
This fixes an issue I was having where I had some tags in quotes b/c they were part of JSON being logged.
